### PR TITLE
fix: replace the `get-changed-files` action with @Ana06's fork

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Get changed files
         id: changed_files
-        uses: jitterbit/get-changed-files@v1
+        uses: Ana06/get-changed-files@v2.2.0
 
       - name: Find add-on directories
         id: addons


### PR DESCRIPTION
See jitterbit/get-changed-files#11. This action appears to be unmaintained and is superceded by Ana06/get-changed-files.