### PR TITLE
fix: update branch protection for the `main` branch

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -7,3 +7,9 @@ repository:
 
   # Enable merge commits for syncing with the addon repository template
   allow_merge_commit: true
+
+branches:
+  - name: main
+    protection:
+      # Allow merging pull requests with a merge commit
+      required_linear_history: false


### PR DESCRIPTION
The main branch is no longer protected against merging pull requests with a
non-linear history. This is to allow syncing the main branch with the upstream
template repository.