### PR TITLE
fix: harden repository governance (P0)

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -12,8 +12,11 @@ branches:
     protection:
       required_status_checks:
         strict: true
-        contexts: ['Prepare', 'Lint', 'Build', 'Renovate / Renovate']
+        contexts: ['Prepare', 'Lint', 'Build', 'Renovate / Renovate', 'Fro Bot']
       enforce_admins: true
-      required_pull_request_reviews: null
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: false
       restrictions: null
       required_linear_history: true

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -12,7 +12,7 @@ branches:
     protection:
       required_status_checks:
         strict: true
-        contexts: ['Prepare', 'Lint', 'Build', 'Renovate / Renovate', 'Fro Bot']
+        contexts: ['Prepare', 'Lint', 'Build', 'Renovate / Renovate']
       enforce_admins: true
       required_pull_request_reviews:
         required_approving_review_count: 1

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -12,7 +12,7 @@ branches:
     protection:
       required_status_checks:
         strict: true
-        contexts: ['Prepare', 'Lint', 'Build', 'Renovate / Renovate']
+        contexts: ['Prepare', 'Lint', 'Build', 'Renovate / Renovate', 'Fro Bot']
       enforce_admins: true
       required_pull_request_reviews:
         required_approving_review_count: 1

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -1,0 +1,228 @@
+---
+name: Fro Bot
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  discussion_comment:
+    types: [created]
+  issues:
+    types: [opened, edited]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, review_requested]
+  schedule:
+    - cron: '30 15 * * *' # Daily at 15:30 UTC
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: Custom prompt for the Fro Bot agent
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: >-
+    fro-bot-${{
+      github.event.issue.number ||
+      github.event.pull_request.number ||
+      github.event.discussion.number ||
+      github.run_id
+    }}
+  cancel-in-progress: false
+
+env:
+  PR_REVIEW_PROMPT: |
+    Review this Home Assistant add-on PR focusing on:
+    - Dockerfile best practices: SHA-pinned base images (ghcr.io/home-assistant/*), minimal
+      layers, non-root safety, s6-overlay service structure
+    - config.yaml / build.yaml validity: required fields (name, version, slug, arch, description),
+      arch list accuracy, correct image reference pattern
+    - Shell script quality (run/finish scripts): bashio usage, signal handling, proper exit codes,
+      shellcheck-passing patterns — avoid SC2086 unquoted variables, SC2060 char class issues
+    - AppArmor profile integrity: capability declarations match script operations, no overly
+      broad access grants, complain-mode is not committed for production
+    - GitHub Actions security: SHA-pinned actions (no @latest/@main/@develop), minimal
+      permissions, no secret leaks, no command injection via untrusted inputs
+    - YAML formatting: 2-space indent, no trailing spaces, consistent quoting style (matches Prettier config)
+    - Breaking changes to add-on interface: removed options, changed option types, slug/image
+      changes that would break existing installations
+    - Translation completeness: en.yaml updated when new config options are added
+
+    Skip style nits — Prettier and markdownlint handle formatting automatically.
+
+    Do NOT push commits, modify code, or create branches. Review only.
+    Use inline comments for file-specific issues. Reserve the review body
+    for the structured summary below.
+
+    You MUST structure your review using exactly these headings:
+    ## Verdict: [PASS | CONDITIONAL | REJECT]
+    CONDITIONAL = can merge after addressing the listed blocking issues.
+    ### Blocking issues
+    ### Non-blocking concerns
+    ### Missing tests
+    ### Risk assessment (LOW/MED/HIGH) + rationale
+    Evaluate likelihood of regression, security exposure, or blast radius.
+    If a section has no items, write "None" under the heading.
+    Do not omit any heading.
+
+  SCHEDULE_PROMPT: |
+    Perform daily repository autohealing for this Home Assistant add-on template repository.
+    Work through each category in order. ALL changes MUST go through pull requests — do NOT
+    commit directly to the default branch. Prefer minimal diffs and avoid destructive changes.
+
+    1. ERRORED PRs
+       Find open PRs with failing CI checks. For each failing PR:
+       a. Check out the PR branch.
+       b. Read the failing check logs to diagnose the root cause.
+       c. Fix the issue (YAML syntax errors, shell script lint failures, Prettier formatting,
+          Dockerfile issues, addon-linter violations).
+       d. Commit with a clear message and push to the PR branch.
+       e. Comment on the PR explaining what failed and what was fixed.
+
+    2. SECURITY
+       Review Renovate alerts and open Renovate PRs for vulnerable or outdated dependencies:
+       - If a security update PR exists but has conflicts or failures, fix and push to that branch.
+       - For unaddressed critical/high advisories affecting Docker base images or GitHub Actions,
+         create a new PR with the remediation.
+       - Check that all GitHub Actions in .github/workflows/*.yaml are SHA-pinned (no @latest,
+         @main, @develop). Pin any unpinned actions to their current SHA via a PR.
+       - Do NOT bulk-update unrelated dependencies in a security PR.
+
+    3. HEALTH & MAINTENANCE
+       Check for outdated dependencies:
+       - .github/workflows/*.yaml: verify SHA-pinned actions are still current (compare against
+         fro-bot/agent, actions/checkout, dorny/paths-filter, frenck/action-addon-linter,
+         creyD/prettier_action, chrisdickinson/setup-yq latest SHAs).
+       - bfra-me/.github reusable workflow version (currently v4.16.6): check if a newer version
+         is available and create a PR to update if so.
+       - .pre-commit-config.yaml: check if hook revisions are current; create a PR if any are
+         significantly outdated.
+       Create one PR per dependency area. Do NOT combine unrelated upgrades.
+
+    4. DEVELOPER EXPERIENCE
+       Ensure consistent formatting and linting across the repository.
+       Run validation where possible and fix any drift:
+       - Prettier formatting: check .github/workflows/*.yaml, *.md, *.json, *.yaml files.
+         Create a PR for formatting fixes if any are found.
+       - Shell script lint (shellcheck): check example/rootfs/**/{run,finish} and any *.sh files.
+         Create a PR for any issues found.
+       - YAML validity: verify config.yaml and build.yaml contain required fields
+         (name, version, slug, arch, description for config; build_from keys for build).
+       - version consistency: confirm config.yaml version matches the latest entry in CHANGELOG.md.
+         If mismatched, create a PR to align them.
+       - Unpinned or missing tool versions in .tool-versions: verify node and python entries
+         match versions referenced in main.yaml and README.md.
+       ALL fixes must go through PRs. Do NOT commit directly to the default branch.
+
+    ## SINGLE ISSUE MANAGEMENT
+
+    Instead of creating new daily issues, you must manage a SINGLE perpetual issue:
+
+    ### Finding the Perpetual Issue
+    1. Search for an open issue titled "Daily Autohealing Report" (exact match)
+    2. If found, use that issue for all updates
+    3. If not found, create a new issue with that exact title
+
+    ### Updating the Issue
+    After completing all work, ADD a dated update section to the TOP of the issue body:
+
+    ```markdown
+    ## Update — YYYY-MM-DD
+
+    ### Summary
+    | Category | Status | Actions |
+    |----------|--------|---------|
+    | ERRORED PRs | ✅/⚠️/➖ | description |
+    | SECURITY | ✅/⚠️/➖ | description |
+    | HEALTH & MAINTENANCE | ✅/⚠️/➖ | description |
+    | DEVELOPER EXPERIENCE | ✅/⚠️/➖ | description |
+
+    ### Tasks for Fro Bot
+    - [ ] Task description (PAT-powered, multi-item work)
+
+    ### Tasks for Copilot
+    - [ ] Task description (assigned task → single PR)
+
+    ### Items Needing Human Attention
+    - Description of blockers or decisions needed
+
+    ---
+    ```
+
+    ### Important Rules
+    - DO NOT create new daily issues
+    - DO NOT close the perpetual issue
+    - ALWAYS prepend new updates to existing content
+    - Use the Task structure above for delegation
+
+    Do NOT comment on individual issues. Update the single perpetual issue only.
+
+jobs:
+  fro-bot:
+    name: Fro Bot
+    runs-on: ubuntu-latest
+    if: >-
+      (
+        github.event.pull_request == null ||
+        (
+          !github.event.pull_request.head.repo.fork &&
+          !endsWith(github.event.pull_request.user.login || '', '[bot]')
+        )
+      ) && (
+        (
+          github.event_name == 'issues' &&
+          !endsWith(github.event.issue.user.login || '', '[bot]') &&
+          (github.event.issue.user.login || '') != 'fro-bot'
+        ) ||
+        (
+          github.event_name == 'pull_request' &&
+          !endsWith(github.event.pull_request.user.login || '', '[bot]') &&
+          (github.event.pull_request.user.login || '') != 'fro-bot'
+        ) ||
+        github.event_name == 'schedule' ||
+        github.event_name == 'workflow_dispatch' ||
+        (
+          (github.event_name == 'issue_comment' ||
+           github.event_name == 'pull_request_review_comment' ||
+           github.event_name == 'discussion_comment') &&
+          contains(github.event.comment.body || '', '@fro-bot') &&
+          (github.event.comment.user.login || '') != 'fro-bot' &&
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+            github.event.comment.author_association || '')
+        )
+      )
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: >-
+            ${{
+              (github.event.issue.pull_request && format('refs/pull/{0}/head',
+                github.event.issue.number))
+              || github.event.pull_request.head.sha
+              || ''
+            }}
+          token: ${{ secrets.FRO_BOT_PAT }}
+
+      - name: Run Fro Bot
+        uses: fro-bot/agent@4247f5e4d1fbd1857617ebe00040f1f95be0071f # v0.40.0
+        env:
+          OPENCODE_PROMPT_ARTIFACT: 'true'
+          PROMPT: >-
+            ${{
+              (github.event_name == 'workflow_dispatch' && (github.event.inputs.prompt || ''))
+              || (github.event_name == 'schedule' && env.SCHEDULE_PROMPT)
+              || (github.event_name == 'pull_request' && env.PR_REVIEW_PROMPT)
+              || ''
+            }}
+        with:
+          auth-json: ${{ secrets.OPENCODE_AUTH_JSON }}
+          github-token: ${{ secrets.FRO_BOT_PAT }}
+          model: ${{ vars.FRO_BOT_MODEL }}
+          omo-providers: ${{ secrets.OMO_PROVIDERS }}
+          opencode-config: ${{ secrets.OPENCODE_CONFIG }}
+          prompt: ${{ env.PROMPT }}


### PR DESCRIPTION
## Summary

Addresses critical P0 governance gaps identified in the project assessment:

- **Enable required PR reviews** — `required_pull_request_reviews` was `null`, meaning anyone could merge unreviewed code to main
- **Add Fro Bot to required status checks** — ensures PR review workflow runs before merge
- **Add Fro Bot workflow** — AI-powered PR reviews and scheduled autohealing
- **Route autohealing through PRs** — all automated changes now go through PRs instead of direct commits to main

## Changes

### `.github/settings.yml`
- Add `Fro Bot` to required status check contexts
- Enable `required_pull_request_reviews` with:
  - 1 required approving review
  - Dismiss stale reviews on new commits
  - No code owner requirement (CODEOWNERS not yet configured)

### `.github/workflows/fro-bot.yaml` (new)
- Comprehensive Fro Bot workflow with all standard triggers
- SHA-pinned actions (`actions/checkout`, `fro-bot/agent`)
- HA-specific PR review prompt covering Dockerfile, config.yaml, shell scripts, AppArmor, Actions security
- Autohealing schedule prompt that routes ALL changes through PRs (no direct main commits)

## Risk Assessment

**LOW** — This change only adds governance guardrails. No functional changes to the addon build or runtime.

## Testing

Fro Bot should automatically review this PR as its first action in this repo, validating the workflow is functional.